### PR TITLE
Modify server state with environment variables

### DIFF
--- a/.default-env
+++ b/.default-env
@@ -1,0 +1,29 @@
+# Port to listen in on
+PORT=3000
+# Authentication secret for JWTs
+AUTH_SECRET="supersecretauthsecret"
+# Admin password
+ADMIN_PASSWORD="admin"
+# MongoDB database URI
+DATABASE_URI="mongodb+srv://localhost:27017"
+
+# Server tick rate
+SERVER_TICK_RATE_MS=100
+
+# Number of horses in the default horse population
+HORSE_POPULATION=100
+# Number of horses to have in a race
+HORSES_PER_RACE=4
+
+# Delay between betting mode beginning and a race starting
+BETTING_DELAY=20
+# Duration of race countdown timer
+PRERACE_DELAY=3
+# Delay between race ending 
+RESULTS_DELAY=10
+
+# Enables cheating (very first horse is always placed at the end of the track)
+# Set it to `"enabled"` to enable cheating.
+CHEAT_MODE=
+# Sets the length of the race
+RACE_LENGTH=500

--- a/src/config/globalsettings.ts
+++ b/src/config/globalsettings.ts
@@ -1,7 +1,7 @@
 export const SERVER_TICK_RATE_MS = Number(process.env.SERVER_TICK_RATE_MS) || 100
 
 export const HORSE_POPULATION = Number(process.env.HORSE_POPULATION) || 100
-export const HORSES_PER_RACE = Number(process.env.HORSE_POPULATION) || 4
+export const HORSES_PER_RACE = Number(process.env.HORSES_PER_RACE) || 4
 
 export const DEFAULT_WALLET = Number(process.env.DEFAULT_WALLET) || 100
 export const BETTING_DELAY = Number(process.env.BETTING_DELAY) || 10

--- a/src/config/globalsettings.ts
+++ b/src/config/globalsettings.ts
@@ -1,0 +1,12 @@
+export const SERVER_TICK_RATE_MS = Number(process.env.SERVER_TICK_RATE_MS) || 100
+
+export const HORSE_POPULATION = Number(process.env.HORSE_POPULATION) || 100
+export const HORSES_PER_RACE = Number(process.env.HORSE_POPULATION) || 4
+
+export const DEFAULT_WALLET = Number(process.env.DEFAULT_WALLET) || 100
+export const BETTING_DELAY = Number(process.env.BETTING_DELAY) || 10
+export const PRERACE_DELAY = Number(process.env.PRERACE_DELAY) || 3
+export const RESULTS_DELAY = Number(process.env.RESULTS_DELAY) || 10
+
+export const CHEAT_MODE = process.env.CHEAT_MODE === 'enabled'
+export const RACE_LENGTH = Number(process.env.RACE_LENGTH) || 10000

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,10 +1,11 @@
 import jwt from 'jsonwebtoken'
 import { NextFunction, Request, Response } from "express";
-import { DEFAULT_WALLET, User } from "../models/User.js";
+import { User } from "../models/User.js";
 import { saltPassword, verifyPassword } from "../auth/password.js";
 import { jwtSecret } from '../auth/secrets.js';
 import { markDeletedUser } from '../auth/tokens.js';
 import { sendJSONError } from '../errorHandler.js';
+import { DEFAULT_WALLET } from '../config/globalsettings.js';
 
 export async function signup(req: Request, res: Response, next: NextFunction) {
     const foundUser = await User.findOne({ username: req.body.username })

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -3,21 +3,16 @@ import corsSettings from './../cors.js'
 import { Socket, Server as SocketIOServer } from "socket.io"
 import { ClientInfo } from "../clientInfo.js"
 import { hrTimeMs } from "../time/time.js"
-import { RACE_DURATION, Race } from './race.js'
+import { Race } from './race.js'
 import { RaceState } from './raceState.js'
-import { HORSES_PER_RACE, createRace } from './horse/localHorses.js'
+import { createRace } from './horse/localHorses.js'
 import { BetInfo } from './betInfo.js'
 import jwt from 'jsonwebtoken'
 import { jwtSecret } from '../auth/secrets.js'
 import { server } from '../app.js'
 import GameLog from '../models/GameLog.js'
 import { User, UserSpec } from '../models/User.js'
-
-export const SERVER_TICK_RATE_MS = 100
-
-export const BETTING_DELAY = Number(process.env.BETTING_DELAY) || 10
-export const PRERACE_DELAY = Number(process.env.PRERACE_DELAY) || 3
-export const RESULTS_DELAY = Number(process.env.RESULTS_DELAY) || 10
+import { BETTING_DELAY, CHEAT_MODE, HORSES_PER_RACE, PRERACE_DELAY, RACE_LENGTH, RESULTS_DELAY, SERVER_TICK_RATE_MS } from '../config/globalsettings.js'
 
 console.log(`Betting delay: ${BETTING_DELAY}`)
 console.log(`Pre-race delay: ${PRERACE_DELAY}`)
@@ -324,7 +319,11 @@ export class GameServer {
         console.log(`Total: ${this.totalPool}`)
 
         this.raceStates = [new RaceState(this.race)]
-        this.raceStates[0].horseStates[0].position = RACE_DURATION-1
+
+        // If cheat mode is enabled, always put horses at the end
+        if (CHEAT_MODE) {
+            this.raceStates[0].horseStates[0].position = RACE_LENGTH-1
+        }
     }
 
     startResultsMode() {
@@ -354,7 +353,7 @@ export class GameServer {
         switch(this.raceStatus) {
         case 'betting':
             if (this.bettingTimer > 0) {
-                this.bettingTimer -= SERVER_TICK_RATE_MS
+                this.bettingTimer -= SERVER_TICK_RATE_MS 
                 return
             }
 

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -303,6 +303,10 @@ export class GameServer {
         this.bets = new Map()
         this.pool = Array(HORSES_PER_RACE).fill(0)
         this.totalPool = 0
+
+        for (const client of this.clients.values()) {
+            this.emitClientStatus(client)
+        }
     }
 
     startRaceMode() {
@@ -441,6 +445,7 @@ export class GameServer {
             const bet = this.bets.get(client.username)
             if (bet === undefined) { continue }
             client.socket.emit('betResults', bet)
+            this.emitClientStatus(client)
         }
     }
 

--- a/src/game/horse/localHorses.ts
+++ b/src/game/horse/localHorses.ts
@@ -1,10 +1,8 @@
+import { HORSES_PER_RACE, HORSE_POPULATION } from "../../config/globalsettings.js";
 import { Horse, HorseSpec, generateNewHorses } from "../../models/Horse.js";
 import { randomIndicesNoReplacement } from "../../random/random.js";
 import { Race } from "../race.js";
 import { InternalHorse } from "./horse.js";
-
-export const HORSE_POPULATION = 100
-export const HORSES_PER_RACE = 4
 
 /** Collection of horses in memory for the game server to access and manipulate */
 export let localHorses: InternalHorse[] = []

--- a/src/game/race.ts
+++ b/src/game/race.ts
@@ -1,11 +1,12 @@
+import { RACE_LENGTH } from "../config/globalsettings.js";
 import { InternalHorse } from "./horse/horse.js";
 
-export const RACE_DURATION = 500
-
 export class Race {
-    horses: Array<InternalHorse>;
+    horses: Array<InternalHorse>
+    length: number
 
     constructor(horses: Array<InternalHorse>) {
         this.horses = horses 
+        this.length = RACE_LENGTH
     }
 }

--- a/src/game/raceState.ts
+++ b/src/game/raceState.ts
@@ -6,6 +6,7 @@ export class RaceState {
     horseStates: Array<HorseState> = []
     rankings: Array<number> = []
     time: number = 0
+    length: number = RACE_LENGTH
 
     constructor(race?: Race) {
         if (race) {

--- a/src/game/raceState.ts
+++ b/src/game/raceState.ts
@@ -1,6 +1,6 @@
+import { RACE_LENGTH, SERVER_TICK_RATE_MS } from "../config/globalsettings.js"
 import { InternalHorse } from "./horse/horse.js"
-import { RACE_DURATION, Race } from "./race.js"
-import { SERVER_TICK_RATE_MS } from "./gameServer.js"
+import { Race } from "./race.js"
 
 export class RaceState {
     horseStates: Array<HorseState> = []
@@ -18,7 +18,7 @@ export class RaceState {
 
     nextState(): RaceState {
         let next = new RaceState()        
-        next.time = this.time + SERVER_TICK_RATE_MS 
+        next.time = this.time + SERVER_TICK_RATE_MS
         next.horseStates = this.horseStates.map((hs) => {
             if (hs.finishTime !== null) { return hs }
             let nextHs = new HorseState(hs.horse)
@@ -26,8 +26,8 @@ export class RaceState {
                 Math.min(hs.currentSpeed + hs.horse.acceleration,
                          hs.horse.topSpeed)
             nextHs.position = hs.position + hs.currentSpeed
-            if (nextHs.position > RACE_DURATION) {
-                nextHs.position = RACE_DURATION
+            if (nextHs.position >= RACE_LENGTH) {
+                nextHs.position = RACE_LENGTH
                 nextHs.finishTime = next.time
             }
 

--- a/src/models/Horse.ts
+++ b/src/models/Horse.ts
@@ -1,6 +1,6 @@
 import mongoose, { Types } from 'mongoose'
 import { randRange, randomIndicesNoReplacement, rollDiceDropLowest } from '../random/random.js'
-import { HORSE_POPULATION } from '../game/horse/localHorses.js'
+import { HORSE_POPULATION } from '../config/globalsettings.js'
 
 const firstNames = [
     'Dashing',

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,7 +1,5 @@
 import mongoose, { Schema, Types } from "mongoose"
 
-export const DEFAULT_WALLET = Number(process.env.DEFAULT_WALLET) || 100
-
 interface IUser {
     username: string,
     passwordHash: string,


### PR DESCRIPTION
This PR adds support for modifying several aspects of the game server (described in the .default-env file) This includes setting the delays for betting, pre-race, and results, modifying the number of horses in the population & the number of horses per race, the length of each race in units, and enabling/disabling cheat mode (placing the first horse at the end of the track so it always wins)