### PR TITLE
Implement updated schema and improve client status events

### DIFF
--- a/.default-env
+++ b/.default-env
@@ -27,3 +27,7 @@ RESULTS_DELAY=10
 CHEAT_MODE=
 # Sets the length of the race
 RACE_LENGTH=500
+# Sets default user wallet upon creating a new account and respawning
+DEFAULT_WALLET=100
+# Sets minimum value of bet
+MINIMUM_BET=10

--- a/src/config/globalsettings.ts
+++ b/src/config/globalsettings.ts
@@ -3,6 +3,7 @@ export const SERVER_TICK_RATE_MS = Number(process.env.SERVER_TICK_RATE_MS) || 10
 export const HORSE_POPULATION = Number(process.env.HORSE_POPULATION) || 100
 export const HORSES_PER_RACE = Number(process.env.HORSES_PER_RACE) || 4
 
+export const MINIMUM_BET = Number(process.env.MINIMUM_BET) || 10
 export const DEFAULT_WALLET = Number(process.env.DEFAULT_WALLET) || 100
 export const BETTING_DELAY = Number(process.env.BETTING_DELAY) || 10
 export const PRERACE_DELAY = Number(process.env.PRERACE_DELAY) || 3

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -250,9 +250,9 @@ export class GameServer {
         // Initially clients are unauthenticated. Clients may authenticate
         // themselves by sending a 'login' message to the server.
         this.clients.set(socket.id, clientInfo)
-
-        // Log all events as they come in.
-        socket.onAny((evt, ...args) => console.log(evt, args))
+        
+        // Set up socket middleware to block all socket requests
+        // that aren't in the clientinfo
 
         // Client closed the connection.
         socket.on('disconnect', () => {
@@ -266,14 +266,6 @@ export class GameServer {
                 callback = (payload: any) => {
                     socket.emit('debuglog', payload)
                 }
-            }
-
-            let clientInfo = this.clients.get(socket.id)
-            if (clientInfo === undefined) {
-                callback({
-                    message: 'Not in client listing'
-                })
-                return
             }
 
             if (this.raceStatus !== 'betting') {
@@ -334,14 +326,6 @@ export class GameServer {
                 callback = (payload: any) => {
                     socket.emit('debuglog', payload)
                 }
-            }
-
-            let clientInfo = this.clients.get(socket.id)
-            if (clientInfo === undefined) {
-                res({
-                    message: 'Not in client listing'
-                })
-                return
             }
 
             if (this.raceStatus !== 'betting') {

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -12,7 +12,7 @@ import { jwtSecret } from '../auth/secrets.js'
 import { server } from '../app.js'
 import GameLog from '../models/GameLog.js'
 import { User, UserSpec } from '../models/User.js'
-import { BETTING_DELAY, CHEAT_MODE, HORSES_PER_RACE, PRERACE_DELAY, RACE_LENGTH, RESULTS_DELAY, SERVER_TICK_RATE_MS } from '../config/globalsettings.js'
+import { BETTING_DELAY, CHEAT_MODE, HORSES_PER_RACE, MINIMUM_BET, PRERACE_DELAY, RACE_LENGTH, RESULTS_DELAY, SERVER_TICK_RATE_MS } from '../config/globalsettings.js'
 
 console.log(`Betting delay: ${BETTING_DELAY}`)
 console.log(`Pre-race delay: ${PRERACE_DELAY}`)
@@ -299,6 +299,13 @@ export class GameServer {
             if (betValue > clientInfo.wallet) {
                 callback({
                     message: 'Not enough balance to make bet'
+                })
+                return
+            }
+
+            if (betValue < MINIMUM_BET) {
+                callback({
+                    message: `Bet must be at least ${MINIMUM_BET}`
                 })
                 return
             }

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -43,6 +43,8 @@ export interface generalStateSchema {
     race: raceDetailsSchema,
     // Current value of the betting pool.
     currentPoolValue: number,
+    // Minimum bet value
+    minimumBet: number,
 }
 
 export interface betStateSchema extends generalStateSchema {
@@ -530,6 +532,7 @@ export class GameServer {
                 raceLength: this.race.length,
             },
             currentPoolValue: this.totalPool,
+            minimumBet: MINIMUM_BET,
         }
 
         switch(this.raceStatus) {

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -230,6 +230,13 @@ export class GameServer {
             return
         }
 
+        for (const client of this.clients.values()) {
+            if (client.username === payload.username) {
+                next(new Error(`User already logged in`))
+                return
+            }
+        }
+
         let user: UserSpec | null
         try {
             user = await User.findOne({ username: payload.username })

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -191,7 +191,7 @@ export class GameServer {
         console.log('Server is now closed')
     }
 
-    async closedMiddleware(socket: Socket, next: (err?: Error | undefined) => void) {
+    async closedMiddleware(_socket: Socket, next: (err?: Error | undefined) => void) {
         console.log('Handling inbound socket.')
         if (this.serverStatus === 'closed') {
             console.log('Rejected: server is closed')

--- a/src/game/gameServer.ts
+++ b/src/game/gameServer.ts
@@ -318,6 +318,13 @@ export class GameServer {
                 return
             }
 
+            if (!isFinite(betValue)) {
+                callback({
+                    message: 'Bet is an invalid numeric quantity'
+                })
+                return
+            }
+
             if (betValue < MINIMUM_BET) {
                 callback({
                     message: `Bet must be at least ${MINIMUM_BET}`
@@ -328,7 +335,7 @@ export class GameServer {
             this.bets.set(clientInfo.username, new BetInfo({
                 username: clientInfo.username,
                 id: clientInfo.id,
-                betValue: betValue,
+                betValue: Math.floor(betValue),
                 horseIdx: horseIdx,
                 horseId: this.race.horses[horseIdx].spec._id,
             }))


### PR DESCRIPTION
This PR adds in the V2 schema.
* Instead of providing constant timer updates in betting and results mode, it will instead provide a timestamp for `raceStartTime` (betting mode), `preraceStartTime` (race mode) and `nextRaceStartTime` (results mode). Updates to the game state in betting and results mode will only be fired once a client connects for the first time, and whenever (in betting mode) the pool changes or when a client connects.
* Improved the `clientStatus` event- it appropriately fires whenever a user places a bet and when their bet results come in.
* Added additional data validation to bets, where bets below a defined minimum value or bets that are not a finite value are rejected.