### PR TITLE
Add autostart toggleable flag to backend

### DIFF
--- a/.default-env
+++ b/.default-env
@@ -1,3 +1,4 @@
+# Copy this into a `.env` file in the root directory
 # Port to listen in on
 PORT=3000
 # Authentication secret for JWTs
@@ -31,3 +32,7 @@ RACE_LENGTH=500
 DEFAULT_WALLET=100
 # Sets minimum value of bet
 MINIMUM_BET=10
+# Set to 'enabled' to automatically start the game loop on server start. Unset
+# to disable this behavior- manually start the server by sending a POST request
+# to `/admin/startRaceLoop` with an admin token.
+AUTOSTART=enabled

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import bodyParser from 'body-parser'
 
 import swaggerUi from 'swagger-ui-express'
 import YAML from 'yamljs'
+import { AUTOSTART } from './config/globalsettings.js'
 
 export const args = {
     readOnly: false,
@@ -63,6 +64,10 @@ app.use(
 )
 
 gameServer.createServer(server)
+
+if (AUTOSTART) {
+    gameServer.startMainLoop()
+}
 
 server.listen(PORT, () => {
     console.log(`listening at http://localhost:${PORT}`)

--- a/src/config/globalsettings.ts
+++ b/src/config/globalsettings.ts
@@ -11,3 +11,4 @@ export const RESULTS_DELAY = Number(process.env.RESULTS_DELAY) || 10
 
 export const CHEAT_MODE = process.env.CHEAT_MODE === 'enabled'
 export const RACE_LENGTH = Number(process.env.RACE_LENGTH) || 10000
+export const AUTOSTART = process.env.AUTOSTART === 'enabled'


### PR DESCRIPTION
Add an additional flag `AUTOSTART` to the backend configuration which, if set to `enabled`, will start the game's main loop on startup